### PR TITLE
Fix typo in version name

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,16 @@
 {% set name = "rte_rrtmgp" %}
-{% set version = "v1.9.1" %}
+{% set version = "1.9.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/earth-system-radiation/rte-rrtmgp/archive/refs/tags/v1.9.1.zip
+  url: https://github.com/earth-system-radiation/rte-rrtmgp/archive/refs/tags/v{{ version }}.zip
   sha256: 3dab2f038414bdbead033f743fa80de2817cb3918894d33f2a0f752c9467eeb2
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:


### PR DESCRIPTION
Because of this typo, on conda forge out package ha double `v` in the version name.
Also packages that refer to us need to use v in the version number, as all other packages only need to specify numbers

On https://anaconda.org/conda-forge/rte_rrtmgp
we're currently listed as `vv1.9.1`